### PR TITLE
build(husky): bumping husky version after husky-init

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -4136,9 +4136,9 @@
       }
     },
     "husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "update:lit": "npx lerna-update-wizard --non-interactive --dependency lit@latest",
     "npmignore": "for d in packages/*/; do cp .npmignore \"$d\"; done",
     "test:pack": "lerna exec 'npm pack --dry-run'",
-    "deps:typereact": "node utils/dependencies/bin/index.js"
+    "deps:typereact": "node utils/dependencies/bin/index.js",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "",
@@ -45,7 +46,7 @@
     "@equinor/eslint-config-fusion": "0.1.3",
     "del-cli": "^4.0.1",
     "eslint": "^7.32.0",
-    "husky": "^7.0.2",
+    "husky": "^8.0.0",
     "lerna": "^4.0.0",
     "lint-staged": "^12.3.3",
     "typescript": "4.6.3"


### PR DESCRIPTION
The new husky pre-commit script, from v8, was uncommitted so the release action failed.
