### PR TITLE
feat/searchabledropdown/styling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
     "printWidth": 120,
-    "singleQuote": true
+    "singleQuote": true,
+    "endOfLine": "lf"
   }

--- a/packages/searchable-dropdown/src/dropdown/element.css.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.css.ts
@@ -20,6 +20,9 @@ export const style = css`
     align-items: center;
     posistion: relative;
   }
+  .no-hover {
+    pointer-events: none;
+  }
   .trailing-slot {
     position: absolute;
     right: 5px;
@@ -28,6 +31,7 @@ export const style = css`
     cursor: pointer;
     margin: 8px 0;
     padding: 0 8px;
+    color: ${unsafeCSS(theme.colors.interactive.primary__resting.getVariable('color'))};
   }
   .trailing-slot:hover {
     background: ${unsafeCSS(theme.colors.interactive.primary__hover_alt.getVariable('color'))};

--- a/packages/searchable-dropdown/src/dropdown/element.css.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.css.ts
@@ -24,7 +24,14 @@ export const style = css`
     position: absolute;
     right: 5px;
     top: 0;
-    height: 100%;
+    height: calc(100% - 16px);
+    cursor: pointer;
+    margin: 8px 0;
+    padding: 0 8px;
+  }
+  .trailing-slot:hover {
+    background: ${unsafeCSS(theme.colors.interactive.primary__hover_alt.getVariable('color'))};
+    border-radius: 50%;
   }
   .fwc-sdd-list {
     position: absolute;

--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -77,7 +77,7 @@ export class SearchableDropdownElement
   initialText = 'Start typing to search';
 
   /* The trailing icon to display in fwc-textinput */
-  trailingIcon = 'search';
+  trailingIcon = 'none';
 
   protected buildListItem(item: SearchableDropdownResultItem): HTMLTemplateResult {
     this.controller._listItems.push(item.id);
@@ -209,6 +209,7 @@ export class SearchableDropdownElement
         <div class="fwc-sdd-input">
           <slot name="leading"></slot>
           <fwc-textinput
+            icon="search"
             label=${ifDefined(this.label)}
             type="search"
             variant=${this.variant}
@@ -219,7 +220,11 @@ export class SearchableDropdownElement
             @keyup=${this.controller.handleKeyup}
           ></fwc-textinput>
           <slot name="trailing"
-            ><fwc-icon @click=${this.trailingClick} class="trailing-slot" icon=${this.trailingIcon} />
+            ><fwc-icon
+              @click=${this.trailingClick}
+              class=${classMap({ 'trailing-slot': true, 'no-hover': this.trailingIcon === 'none' })}
+              icon=${this.trailingIcon}
+            />
           </slot>
         </div>
         <div class="fwc-sdd-list">${this.renderList()}</div>

--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -35,7 +35,8 @@ import { styles as CSSstyles } from './element.css';
  * @property {string} graphic Icon to show before each fwc-list-item. If you want an icon only on one list-item then use the meta property on the SearchableDropdownResultItem
  * @property {string} selected Display selected item's title
  * @property {string} initialText Text to display in dropdown before/without querystring in fwc-textinput
- * @property {string} trailingIcon Traling Icon to display in fwc-text-input
+ * @property {string} trailingIcon Trailing Icon to display in fwc-text-input
+ * @property {string} leadingIcon Leading Icon to display in fwc-text-input
  *
  * @fires action Fires when a selection has been made on the fwc-list element
  */
@@ -76,8 +77,12 @@ export class SearchableDropdownElement
   @property()
   initialText = 'Start typing to search';
 
+  /* The leading icon to display in fwc-textinput */
+  @property()
+  leadingIcon = 'search';
+
   /* The trailing icon to display in fwc-textinput */
-  trailingIcon = 'none';
+  trailingIcon = '';
 
   protected buildListItem(item: SearchableDropdownResultItem): HTMLTemplateResult {
     this.controller._listItems.push(item.id);
@@ -209,7 +214,7 @@ export class SearchableDropdownElement
         <div class="fwc-sdd-input">
           <slot name="leading"></slot>
           <fwc-textinput
-            icon="search"
+            icon=${this.leadingIcon}
             label=${ifDefined(this.label)}
             type="search"
             variant=${this.variant}
@@ -222,7 +227,7 @@ export class SearchableDropdownElement
           <slot name="trailing"
             ><fwc-icon
               @click=${this.trailingClick}
-              class=${classMap({ 'trailing-slot': true, 'no-hover': this.trailingIcon === 'none' })}
+              class=${classMap({ 'trailing-slot': true, 'no-hover': this.trailingIcon === '' })}
               icon=${this.trailingIcon}
             />
           </slot>

--- a/packages/searchable-dropdown/src/provider/controller.ts
+++ b/packages/searchable-dropdown/src/provider/controller.ts
@@ -158,7 +158,7 @@ export class SearchableDropdownController implements ReactiveController {
   public set isOpen(state: boolean) {
     this.#queryString = '';
     this._isOpen = state;
-    this.#host.trailingIcon = state ? 'close' : 'search';
+    this.#host.trailingIcon = state ? 'close' : 'none';
     this.#host.requestUpdate();
   }
 

--- a/packages/searchable-dropdown/src/provider/controller.ts
+++ b/packages/searchable-dropdown/src/provider/controller.ts
@@ -158,7 +158,7 @@ export class SearchableDropdownController implements ReactiveController {
   public set isOpen(state: boolean) {
     this.#queryString = '';
     this._isOpen = state;
-    this.#host.trailingIcon = state ? 'close' : 'none';
+    this.#host.trailingIcon = state ? 'close' : '';
     this.#host.requestUpdate();
   }
 

--- a/packages/searchable-dropdown/src/types.ts
+++ b/packages/searchable-dropdown/src/types.ts
@@ -4,7 +4,12 @@ import { ReactiveControllerHost } from 'lit';
  * Properties/Attributes for web component
  * @label TextInput Label
  * @placeholder TextInput placeholder
- * @placeholder TextInput placeholder
+ * @variant Set variant to filled|outlined on fwc-textinput and fwc-list elements
+ * @meta Icon to show after each fwc-list-item.
+ * @graphic Icon to show before each fwc-list-item.
+ * @selected Display selected item's title
+ * @initialText Text to display in dropdown before/without querystring in fwc-textinput
+ * @leadingIcon Leading Icon to display in fwc-text-input
  */
 export type SearchableDropdownProps = {
   label?: string;
@@ -14,6 +19,7 @@ export type SearchableDropdownProps = {
   graphic?: string;
   selected?: string;
   initialText?: string;
+  leadingIcon?: string;
 };
 
 /**


### PR DESCRIPTION
Hover styling on trailing icon:
 - Circular background with eds hover color
 - Cursor: pointer
 - padding/margin

Moved search icon to front. 
Hide trailing icon when dropdown is closed.