### PR TITLE
Feat/searchabledropdown/autofocus

### DIFF
--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -50,6 +50,8 @@ export class SearchableDropdownElement
   extends LitElement
   implements SearchableDropdownProps, SearchableDropdownControllerHost
 {
+  static shadowRootOptions = { ...Object.assign(LitElement.shadowRootOptions, { delegatesFocus: true }) };
+
   /* style object css */
   static styles = [sddStyles];
 
@@ -264,6 +266,9 @@ export class SearchableDropdownElement
         </div>
       </div>
       <style>
+        input[name='eik']:focus {
+          background: red;
+        }
         .list-scroll {
           max-height: ${this.dropdownHeight};
         }

--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -29,7 +29,7 @@ import { styles as sddStyles } from './element.css';
  * Element for SearchableDropdown
  * @tag fwc-searchabledropdown
  *
- * @property {boolean} autofocus Focus the tetinput on hostconnect
+ * @property {boolean} autofocus Focus the fwx-textInput on hostconnect
  * @property {string} label Label for fwc-textinput element
  * @property {string} placeholder Placeholder text for fwc-textinput element
  * @property {string} value value for TextInput element

--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -1,5 +1,8 @@
 import { html, LitElement, HTMLTemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
+
+import { query } from 'lit/decorators/query.js';
+
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { v4 as uuid } from 'uuid';
@@ -98,6 +101,9 @@ export class SearchableDropdownElement
 
   @property()
   autofocus = false;
+
+  @query('fwc-textinput')
+  textInputElement: TextInputElement | undefined;
 
   /* Build fwc-list-items */
   protected buildListItem(item: SearchableDropdownResultItem): HTMLTemplateResult {

--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -29,6 +29,7 @@ import { styles as sddStyles } from './element.css';
  * Element for SearchableDropdown
  * @tag fwc-searchabledropdown
  *
+ * @property {boolean} autofocus Focus the tetinput on hostconnect
  * @property {string} label Label for fwc-textinput element
  * @property {string} placeholder Placeholder text for fwc-textinput element
  * @property {string} value value for TextInput element
@@ -94,6 +95,9 @@ export class SearchableDropdownElement
   /* Label passed to the fwc-text-input component */
   @property()
   dropdownHeight = '250px';
+
+  @property()
+  autofocus = false;
 
   /* Build fwc-list-items */
   protected buildListItem(item: SearchableDropdownResultItem): HTMLTemplateResult {

--- a/packages/searchable-dropdown/src/provider/controller.ts
+++ b/packages/searchable-dropdown/src/provider/controller.ts
@@ -274,6 +274,14 @@ export class SearchableDropdownController implements ReactiveController {
     if (this.#externaCloseHandler) {
       this.#externaCloseHandler(e);
     }
+
+    /* fire event for sdd closed */
+    const event = new CustomEvent('searchable-dropdown-closed', {
+      bubbles: true,
+      composed: true,
+      cancelable: false,
+    });
+    this.#host.dispatchEvent(event);
   };
 
   /* Settter: Open/Closed state for host */

--- a/packages/searchable-dropdown/src/provider/controller.ts
+++ b/packages/searchable-dropdown/src/provider/controller.ts
@@ -16,6 +16,7 @@ export class SearchableDropdownController implements ReactiveController {
   protected _isOpen = false;
   protected resolver?: SearchableDropdownResolver;
 
+  public textInput: TextInputElement | null = null;
   public _listItems: Array<string> = [];
   public _selectedItems: SearchableDropdownResult = [];
   public result?: SearchableDropdownResult;
@@ -73,6 +74,15 @@ export class SearchableDropdownController implements ReactiveController {
   };
 
   public hostConnected(): void {
+    requestAnimationFrame(() => {
+      this.textInput = this.#host.renderRoot.querySelector('fwc-textinput');
+      if (this.textInput) {
+        if (this.#host.autofocus) {
+          this.textInput.focus();
+        }
+      }
+    });
+
     const event = new SearchableDropdownConnectEvent({
       detail: {
         disconnectedCallback: (callback) => {
@@ -85,6 +95,7 @@ export class SearchableDropdownController implements ReactiveController {
       cancelable: false,
     });
     this.#host.dispatchEvent(event);
+
     /* add click event to window */
     window.addEventListener('click', this._handleWindowClick);
   }
@@ -115,10 +126,10 @@ export class SearchableDropdownController implements ReactiveController {
   private _handleWindowKeyUp = (e: KeyboardEvent): void => {
     /* Close on Escape */
     if (e.key === 'Escape') {
-      /* unfocus */
-      const input: TextInputElement | null = this.#host.renderRoot.querySelector('fwc-textinput');
-      if (input) {
-        input.blur();
+      this.textInput = this.textInput ?? this.#host.renderRoot.querySelector('fwc-textinput');
+      if (this.textInput) {
+        /* unfocus */
+        this.textInput.blur();
       }
       /* Close element */
       this.isOpen = false;
@@ -242,6 +253,7 @@ export class SearchableDropdownController implements ReactiveController {
     /* Refresh host */
     this.#host.requestUpdate();
   }
+
   /**
    * Fires on click on close icon in textinput
    * Calls closeHandler callback set in resolver
@@ -263,6 +275,7 @@ export class SearchableDropdownController implements ReactiveController {
   /* Settter: Open/Closed state for host */
   public set isOpen(state: boolean) {
     this._isOpen = state;
+    // toogle close icon
     this.#host.trailingIcon = state ? 'close' : '';
 
     /* Sets items isSelected in result list */

--- a/packages/searchable-dropdown/src/provider/controller.ts
+++ b/packages/searchable-dropdown/src/provider/controller.ts
@@ -111,8 +111,10 @@ export class SearchableDropdownController implements ReactiveController {
   private _handleWindowClick = (e: Event): void => {
     /* make sure we have a target to check against */
     if (!e.target) return;
-    const target = e.target as HTMLElement;
-    if (target.nodeName !== this.#host.nodeName) {
+    if (
+      (e.target as HTMLElement).nodeName !== this.#host.nodeName &&
+      document.activeElement?.nodeName !== this.#host.nodeName
+    ) {
       this.isOpen = false;
     }
   };
@@ -258,6 +260,7 @@ export class SearchableDropdownController implements ReactiveController {
     /* needed to clear user input */
     if (this.#host.textInputElement) {
       this.#host.textInputElement.value = '';
+      this.#host.textInputElement.blur();
     }
 
     this.#host.value = '';

--- a/packages/searchable-dropdown/src/provider/controller.ts
+++ b/packages/searchable-dropdown/src/provider/controller.ts
@@ -276,12 +276,13 @@ export class SearchableDropdownController implements ReactiveController {
     }
 
     /* fire event for sdd closed */
-    const event = new CustomEvent('searchable-dropdown-closed', {
+    const ddClosedEvent = new CustomEvent<{ date: number }>('dropdownClosed', {
+      detail: {
+        date: Date.now(),
+      },
       bubbles: true,
-      composed: true,
-      cancelable: false,
     });
-    this.#host.dispatchEvent(event);
+    this.#host.dispatchEvent(ddClosedEvent);
   };
 
   /* Settter: Open/Closed state for host */

--- a/packages/searchable-dropdown/src/provider/element.ts
+++ b/packages/searchable-dropdown/src/provider/element.ts
@@ -7,6 +7,7 @@ import { SearchableDropdownResolver, SearchableDropdownConnectEvent } from '../t
 export class SearchableDropdownProviderElement extends LitElement {
   protected resolverCallbacks: Array<(resolver?: SearchableDropdownResolver) => void> = [];
   #resolver?: SearchableDropdownResolver;
+
   protected createRenderRoot(): LitElement {
     return this;
   }

--- a/packages/searchable-dropdown/src/types.ts
+++ b/packages/searchable-dropdown/src/types.ts
@@ -12,7 +12,8 @@ import { ActionDetail } from '@material/mwc-list/mwc-list-foundation';
  * @leadingIcon Leading Icon to display in fwc-text-input
  * @dropdownHeight Sets max-height of the dropdown
  */
-export type SearchableDropdownProps = {
+export interface SearchableDropdownProps {
+  autofocus: boolean;
   label?: string;
   placeholder?: string;
   value?: string;
@@ -23,10 +24,10 @@ export type SearchableDropdownProps = {
   initialText?: string;
   leadingIcon?: string;
   dropdownHeight?: string;
-};
+}
 
 /**
- * Array of SearchableDropdownResultItem
+ * Array of SearchableDropdownResultItem's
  */
 export type SearchableDropdownResult = Array<SearchableDropdownResultItem>;
 
@@ -68,15 +69,11 @@ export interface SearchableDropdownResolver {
 /**
  * The element the controller is conected to
  */
-export interface SearchableDropdownControllerHost extends ReactiveControllerHost {
+export interface SearchableDropdownControllerHost extends SearchableDropdownProps, ReactiveControllerHost {
   renderRoot: HTMLElement | ShadowRoot;
   dispatchEvent(event: Event): boolean;
   nodeName: string;
-  multiple: boolean;
-  value: string;
   trailingIcon: string;
-  initialText: string;
-  variant: string;
 }
 
 export interface ExplicitEventTarget extends Event {

--- a/packages/searchable-dropdown/src/types.ts
+++ b/packages/searchable-dropdown/src/types.ts
@@ -24,7 +24,7 @@ export interface SearchableDropdownProps {
   initialText?: string;
   leadingIcon?: string;
   dropdownHeight?: string;
-  textInputElement: TextInputElement | undefined;
+  textInputElement?: TextInputElement;
 }
 
 /**

--- a/packages/searchable-dropdown/src/types.ts
+++ b/packages/searchable-dropdown/src/types.ts
@@ -1,6 +1,6 @@
 import { ReactiveControllerHost } from 'lit';
 import { ActionDetail } from '@material/mwc-list/mwc-list-foundation';
-
+import { TextInputElement } from '@equinor/fusion-wc-textinput';
 /**
  * Properties/Attributes for web component
  * @label TextInput Label
@@ -13,7 +13,7 @@ import { ActionDetail } from '@material/mwc-list/mwc-list-foundation';
  * @dropdownHeight Sets max-height of the dropdown
  */
 export interface SearchableDropdownProps {
-  autofocus: boolean;
+  autofocus?: boolean;
   label?: string;
   placeholder?: string;
   value?: string;
@@ -24,6 +24,7 @@ export interface SearchableDropdownProps {
   initialText?: string;
   leadingIcon?: string;
   dropdownHeight?: string;
+  textInputElement: TextInputElement | undefined;
 }
 
 /**

--- a/storybook/stories/Components/SearchableDropdown.tsx
+++ b/storybook/stories/Components/SearchableDropdown.tsx
@@ -112,7 +112,7 @@ const useSearchableDropdownProviderRef = (
     if (providerRef?.current) {
       providerRef.current.connectResolver(resolver);
       providerRef?.current.addEventListener('select', (e) => console.log('Event', e));
-      providerRef?.current.addEventListener('searchable-dropdown-closed', (e) => console.log('Event', e));
+      providerRef?.current.addEventListener('dropdownClosed', (e) => console.log('Event', e));
       return () => {
         providerRef.current?.removeResolver();
         providerRef.current?.removeEventListener('select', (e) => console.log('Event', e));

--- a/storybook/stories/Components/SearchableDropdown.tsx
+++ b/storybook/stories/Components/SearchableDropdown.tsx
@@ -127,7 +127,7 @@ export const SearchableDropdown = ({ children, ...props }: PropsWithChildren<Sea
 
   return (
     <fwc-searchable-dropdown-provider ref={providerRef}>
-      <fwc-searchable-dropdown {...extractProps<SearchableDropdownProps>(props)}>{children}</fwc-searchable-dropdown>
+      <fwc-searchable-dropdown {...extractProps(props)}>{children}</fwc-searchable-dropdown>
     </fwc-searchable-dropdown-provider>
   );
 };

--- a/storybook/stories/Components/SearchableDropdown.tsx
+++ b/storybook/stories/Components/SearchableDropdown.tsx
@@ -112,6 +112,7 @@ const useSearchableDropdownProviderRef = (
     if (providerRef?.current) {
       providerRef.current.connectResolver(resolver);
       providerRef?.current.addEventListener('select', (e) => console.log('Event', e));
+      providerRef?.current.addEventListener('searchable-dropdown-closed', (e) => console.log('Event', e));
       return () => {
         providerRef.current?.removeResolver();
         providerRef.current?.removeEventListener('select', (e) => console.log('Event', e));

--- a/storybook/stories/searchabledropdown.stories.mdx
+++ b/storybook/stories/searchabledropdown.stories.mdx
@@ -1,7 +1,8 @@
 import { Meta, Story, Canvas, ArgsTable, Description } from '@storybook/addon-docs';
 import readme from '@equinor/fusion-wc-searchable-dropdown/README.md';
 import { PackageInfo } from './Components';
-import SearchableDropdown, {apiQuery, _handleEvent} from './Components/SearchableDropdown';
+import SearchableDropdown from './Components/SearchableDropdown';
+
 export const Container = ({ title, children }) => (
   <section>
     <h4>{title}</h4>

--- a/storybook/stories/searchabledropdown.stories.mdx
+++ b/storybook/stories/searchabledropdown.stories.mdx
@@ -78,6 +78,9 @@ export const Template = ({ children, ...props }) => {
       graphic: {
         description: 'A fwc-icon name to show BEFORE each list item. may also be set per result item.'
       },
+      autofocus: {
+        description: 'Flag for setting focus on textInput on component mount',
+      },
       multiple: {
         description: 'Flag for selecting multiple items.'
       }

--- a/storybook/stories/searchabledropdown.stories.mdx
+++ b/storybook/stories/searchabledropdown.stories.mdx
@@ -79,6 +79,7 @@ export const Template = ({ children, ...props }) => {
         description: 'A fwc-icon name to show BEFORE each list item. may also be set per result item.'
       },
       autofocus: {
+        type: 'boolean',
         description: 'Flag for setting focus on textInput on component mount',
       },
       multiple: {


### PR DESCRIPTION
Adding ``autofocus`` property to ``fusion-wc-searchable-dropdown`` so consumer can put focus on the child component ``fwc-textinput`` when  component is connected to DOM.

Also exposing ``textInput`` from the controller so consumer can access the ``fwc-textinput`` child component element in the ShadowDOM.