### PR TITLE
fix(chip): double trigger on remove click

### DIFF
--- a/packages/chip/src/element.ts
+++ b/packages/chip/src/element.ts
@@ -131,9 +131,7 @@ export class ChipElement extends LitElement implements ChipElementProps {
    * Render the remove icon.
    */
   protected renderRemoveIcon(): TemplateResult | null {
-    return this.removable
-      ? html`<fwc-icon class="fwc-chip__remove" icon="close" @click=${this.handleRemoveOnClick}> </fwc-icon>`
-      : null;
+    return this.removable ? html`<fwc-icon class="fwc-chip__remove" icon="close"></fwc-icon>` : null;
   }
 
   /**
@@ -165,6 +163,7 @@ export class ChipElement extends LitElement implements ChipElementProps {
    * Handle remove icon on click.
    */
   protected handleRemoveOnClick(e: PointerEvent): void {
+    e.stopPropagation();
     if (this.removable) {
       this.dispatchEvent(new PointerEvent('remove', e));
     }

--- a/packages/chip/src/index.ts
+++ b/packages/chip/src/index.ts
@@ -1,5 +1,5 @@
 import { fusionElement } from '@equinor/fusion-wc-core';
-import { ChipElement } from './element';
+import { ChipElement, ChipElementProps } from './element';
 export * from './element';
 export { IconName } from '@equinor/fusion-wc-icon';
 
@@ -11,5 +11,11 @@ export default class _ extends ChipElement {}
 declare global {
   interface HTMLElementTagNameMap {
     [tag]: ChipElement;
+  }
+
+  namespace JSX {
+    interface IntrinsicElements {
+      [tag]: React.DetailedHTMLProps<React.PropsWithChildren<ChipElementProps>, ChipElement>;
+    }
   }
 }


### PR DESCRIPTION
## `onRemove` triggers twice

- add namespace JSX for Chip
- remove click from icon
- stopPropagation when clicking on remove, to stop parent click

close #665 