### PR TITLE
feat(person)!: update the default method for showing card to hover

### DIFF
--- a/packages/person/src/components/avatar/element.ts
+++ b/packages/person/src/components/avatar/element.ts
@@ -80,7 +80,7 @@ export class PersonAvatarElement
   clickable?: boolean;
 
   @property({ type: String, attribute: true, reflect: true })
-  showFloatingOn: PersonAvatarShowCardOnType = 'click';
+  showFloatingOn: PersonAvatarShowCardOnType = 'hover';
 
   /**
    * Sets the avatar to be rendered as disabled.


### PR DESCRIPTION
BREAKING: Will now show card on hover, rather than click as the default.

Closes #809