### PR TITLE
feat(person): allow partial resolver

### DIFF
--- a/packages/person/src/components/provider/controller.ts
+++ b/packages/person/src/components/provider/controller.ts
@@ -1,0 +1,87 @@
+import { ReactiveController } from 'lit';
+import { PersonResolver, PersonResolverHost } from './types';
+import {
+  RequestResolvePersonDetailEvent,
+  RequestResolvePersonInfoEvent,
+  RequestResolvePersonSearchEvent,
+  RequestResolvePersonPhotoEvent,
+  ResolveEventDetail,
+} from '../../events';
+
+type PersonResolverEventMap = Record<string, keyof PersonResolver>;
+
+/** default mapping of events to resolver function */
+const defaultEventMap: PersonResolverEventMap = {
+  [RequestResolvePersonDetailEvent.eventName]: 'getDetails',
+  [RequestResolvePersonInfoEvent.eventName]: 'getInfo',
+  [RequestResolvePersonPhotoEvent.eventName]: 'getPhoto',
+  [RequestResolvePersonSearchEvent.eventName]: 'search',
+};
+
+const processEvent = (
+  event: CustomEvent<ResolveEventDetail>,
+  resolver: PersonResolver,
+  fnName: keyof PersonResolver,
+) => {
+  const fn = resolver[fnName];
+  if (fn) {
+    event.detail.result = (fn as (args: unknown) => unknown)(event.detail);
+    event.stopPropagation();
+  }
+};
+
+const eventFactory = (host: PersonResolverHost, options?: AddEventListenerOptions | boolean) => {
+  return (eventName: string, fnName: keyof PersonResolver) => {
+    host.addEventListener(
+      eventName,
+      (event) => {
+        if (host.resolver) {
+          processEvent(event as CustomEvent<ResolveEventDetail>, host.resolver, fnName);
+        }
+      },
+      options,
+    );
+  };
+};
+
+const addEventListeners = (host: PersonResolverHost, eventMap: PersonResolverEventMap) => {
+  const controller = new AbortController();
+  const addEventListener = eventFactory(host, {
+    capture: false,
+    passive: true,
+    signal: controller.signal,
+  });
+  Object.entries(eventMap).forEach(([eventName, fnName]) => {
+    addEventListener(eventName, fnName);
+  });
+  return controller;
+};
+
+export class PersonResolverController implements ReactiveController {
+  public resolver: PersonResolver | undefined = undefined;
+
+  #host: PersonResolverHost;
+  #controller?: AbortController;
+  #options: {
+    events: PersonResolverEventMap;
+  };
+
+  constructor(
+    host: PersonResolverHost,
+    options?: {
+      events?: PersonResolverEventMap;
+    },
+  ) {
+    this.#host = host;
+    this.#host.addController(this);
+    this.#options = { events: defaultEventMap, ...options };
+  }
+
+  hostConnected(): void {
+    this.#controller = addEventListeners(this.#host, this.#options.events);
+  }
+
+  hostDisconnected() {
+    this.#controller?.abort();
+  }
+}

--- a/packages/person/src/components/provider/element.ts
+++ b/packages/person/src/components/provider/element.ts
@@ -1,65 +1,25 @@
 import { LitElement } from 'lit';
 import { PersonResolver } from '.';
-import {
-  RequestResolvePersonDetailEvent,
-  RequestResolvePersonInfoEvent,
-  RequestResolvePersonPhotoEvent,
-  RequestResolvePersonSearchEvent,
-} from '../../events';
+
+import { PersonResolverHost } from './types';
+import { PersonResolverController } from './controller';
 
 // TODO add styling to display: contents
-export class PersonProviderElement extends LitElement {
-  protected resolver: PersonResolver | undefined = undefined;
+export class PersonProviderElement extends LitElement implements PersonResolverHost {
+  resolver?: PersonResolver = undefined;
+
+  constructor() {
+    super();
+    new PersonResolverController(this);
+  }
 
   createRenderRoot(): LitElement {
     return this;
   }
 
-  setResolver(resolver?: PersonResolver): void {
-    this.resolver = resolver;
-  }
-
   override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener(RequestResolvePersonDetailEvent.eventName, this.handleResolvePersonDetail);
-    this.addEventListener(RequestResolvePersonInfoEvent.eventName, this.handleResolvePersonInfo);
-    this.addEventListener(RequestResolvePersonSearchEvent.eventName, this.handleResolvePersonSearch);
-    this.addEventListener(RequestResolvePersonPhotoEvent.eventName, this.handleResolvePersonPhoto);
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.removeEventListener(RequestResolvePersonDetailEvent.eventName, this.handleResolvePersonDetail);
-    this.removeEventListener(RequestResolvePersonInfoEvent.eventName, this.handleResolvePersonInfo);
-    this.removeEventListener(RequestResolvePersonSearchEvent.eventName, this.handleResolvePersonSearch);
-    this.removeEventListener(RequestResolvePersonPhotoEvent.eventName, this.handleResolvePersonPhoto);
-  }
-
-  protected handleResolvePersonDetail(e: RequestResolvePersonDetailEvent) {
-    if (this.resolver) {
-      e.detail.result = this.resolver.getDetails(e.detail);
-      e.stopPropagation();
-    }
-  }
-
-  protected handleResolvePersonInfo(e: RequestResolvePersonInfoEvent) {
-    if (this.resolver) {
-      e.detail.result = this.resolver.getInfo(e.detail);
-      e.stopPropagation();
-    }
-  }
-
-  protected handleResolvePersonSearch(e: RequestResolvePersonSearchEvent) {
-    if (this.resolver) {
-      e.detail.result = this.resolver.search(e.detail);
-      e.stopPropagation();
-    }
-  }
-  protected handleResolvePersonPhoto(e: RequestResolvePersonPhotoEvent) {
-    if (this.resolver) {
-      e.detail.result = this.resolver.getPhoto(e.detail);
-      e.stopPropagation();
-    }
+    this.style.display = 'contents';
   }
 }
 

--- a/packages/person/src/components/provider/types.ts
+++ b/packages/person/src/components/provider/types.ts
@@ -7,14 +7,13 @@ type ResolverArgs<T = unknown> = T extends object
 
 type ResolverResult<T = unknown> = T | Promise<T>;
 
-export interface PersonHost extends ReactiveControllerHost {
-  azureId: string;
-  dispatchEvent(event: Event): boolean;
+export interface PersonResolverHost extends ReactiveControllerHost, EventTarget {
+  resolver?: PersonResolver;
 }
 
 export interface PersonResolver {
-  getDetails: (args: ResolverArgs<AzureIdOrUpnObj>) => ResolverResult<PersonDetails>;
-  getInfo: (args: ResolverArgs<AzureIdOrUpnObj>) => ResolverResult<PersonInfo>;
-  getPhoto: (args: ResolverArgs<AzureIdOrUpnObj>) => ResolverResult<string>;
-  search: (args: ResolverArgs<{ search: string }>) => ResolverResult<PersonSearchResult>;
+  getDetails?: (args: ResolverArgs<AzureIdOrUpnObj>) => ResolverResult<PersonDetails>;
+  getInfo?: (args: ResolverArgs<AzureIdOrUpnObj>) => ResolverResult<PersonInfo>;
+  getPhoto?: (args: ResolverArgs<AzureIdOrUpnObj>) => ResolverResult<string>;
+  search?: (args: ResolverArgs<{ search: string }>) => ResolverResult<PersonSearchResult>;
 }

--- a/packages/person/src/events.ts
+++ b/packages/person/src/events.ts
@@ -4,7 +4,7 @@ export type AbortableEventDetail<T = unknown> = T extends object
   ? { [K in keyof T]: T[K] } & { signal?: AbortSignal }
   : { signal?: AbortSignal };
 
-type ResolveEventDetail<T = unknown, R = unknown> = AbortableEventDetail<T> & { result?: R | Promise<R> };
+export type ResolveEventDetail<T = unknown, R = unknown> = AbortableEventDetail<T> & { result?: R | Promise<R> };
 
 abstract class RequestResolveEvent<T, R> extends CustomEvent<ResolveEventDetail<T, R>> {
   constructor(

--- a/storybook/stories/Components/PersonAvatar.tsx
+++ b/storybook/stories/Components/PersonAvatar.tsx
@@ -18,7 +18,7 @@ const usePersonProviderRef = (personResolver: PersonResolver): MutableRefObject<
 
   useEffect(() => {
     if (providerRef?.current) {
-      providerRef.current.setResolver(personResolver);
+      providerRef.current.resolver = personResolver;
     }
   }, [providerRef, personResolver]);
 

--- a/storybook/stories/Components/PersonCard.tsx
+++ b/storybook/stories/Components/PersonCard.tsx
@@ -16,7 +16,7 @@ const usePersonProviderRef = (personResolver: PersonResolver): MutableRefObject<
 
   useEffect(() => {
     if (providerRef?.current) {
-      providerRef.current.setResolver(personResolver);
+      providerRef.current.resolver = personResolver;
     }
   }, [providerRef]);
 

--- a/storybook/stories/Components/PersonListItem.tsx
+++ b/storybook/stories/Components/PersonListItem.tsx
@@ -17,7 +17,7 @@ const usePersonProviderRef = (personResolver: PersonResolver): MutableRefObject<
 
   useEffect(() => {
     if (providerRef?.current) {
-      providerRef.current.setResolver(personResolver);
+      providerRef.current.resolver = personResolver;
     }
   }, [providerRef]);
 

--- a/storybook/stories/Components/PersonSearch.tsx
+++ b/storybook/stories/Components/PersonSearch.tsx
@@ -16,7 +16,7 @@ const usePersonProviderRef = (personResolver: PersonResolver): MutableRefObject<
 
   useEffect(() => {
     if (providerRef?.current) {
-      providerRef.current.setResolver(personResolver);
+      providerRef.current.resolver = personResolver;
     }
   }, [providerRef, personResolver]);
 


### PR DESCRIPTION
- make `PersonResolver` partial
- allow setting resolver threw prop
- update stories
- create reusable controller for connecting event to resolver
- only stop propagation if resolver has implementation for mapped event

__WHY__

When overriding the provider, a partial resolver is required to not force implementation of all functionality of the resolver

```html
<fwc-person-provider .resolver={resolver}>
  <!-- will do default search -->
  <fwc-person-search></fwc-person-search>
  <fwc-person-provider .resolver={customResolver}>
    <!-- only display person with title 'foobar', but images are resolved from parent provider -->
    <fwc-person-search></fwc-person-search>
  </fwc-person-provider>
</fwc-person-provider>
```
```ts
const controller: MainController;
const resolver: PersonResolver = {
  search: (args) => controller.search(args),
  getPhoto: (args) => controller.getPhoto(args)
}
const customResolver: PersonResolver = {
  search: (args) => controller.search(args).filter(x => x.title === 'foobar'),
}
```