### PR TITLE
fix(person-select): fixing typo in console.warn

### DIFF
--- a/packages/person/src/components/select/controller.ts
+++ b/packages/person/src/components/select/controller.ts
@@ -109,7 +109,7 @@ export class PersonSelectController implements ReactiveController {
     const { azureId } = dataSource ?? {};
 
     if (!azureId) {
-      console.warn('This should not be spossible, missing dataSource?');
+      console.warn('This should not be possible, is dataSource missing?');
       return;
     }
 


### PR DESCRIPTION
PersonSelect had a typo in console warning.