### PR TITLE
Fix/person/select/preselected

### DIFF
--- a/.changeset/weak-shoes-doubt.md
+++ b/.changeset/weak-shoes-doubt.md
@@ -1,0 +1,6 @@
+---
+'@equinor/fusion-wc-person': minor
+'@equinor/fusion-wc-storybook': patch
+---
+
+Add property ``selectedPerson`` to programmatically set or clear a person

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": "^18",
+    "node": "^18 || ^20",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
     "pnpm": ">=4"

--- a/packages/person/src/components/select/controller.ts
+++ b/packages/person/src/components/select/controller.ts
@@ -160,12 +160,6 @@ export class PersonSelectController implements ReactiveController {
       }
     }
 
-    /* Make sure input is clean */
-    if (personData === null) {
-      this.#host.search = '';
-      this.#host.value = '';
-    }
-
     /* Dispatch custom select event with our details */
     this.#host.dispatchEvent(
       new PersonSelectEvent({
@@ -177,7 +171,7 @@ export class PersonSelectController implements ReactiveController {
     );
 
     /* clear component after selection */
-    if (this.#host.selectedPerson === null) {
+    if (personData === null || this.#host.selectedPerson === null) {
       this.clearInput();
     }
   }

--- a/packages/person/src/components/select/index.ts
+++ b/packages/person/src/components/select/index.ts
@@ -1,12 +1,19 @@
 import { fusionElement } from '@equinor/fusion-wc-core';
 import PersonSelectElement from './element';
 import { type SearchableDropdownProps } from '@equinor/fusion-wc-searchable-dropdown';
+import { PersonInfo } from '../../types';
 
 export * from './element';
 
 export type { PersonSelectEvent } from './controller';
 
-export type PersonSelectElementProps = Partial<SearchableDropdownProps>;
+export interface SelectedPersonProp {
+  selectedPerson?: PersonInfo | string | null;
+}
+
+interface PersonSelectProps extends SelectedPersonProp, SearchableDropdownProps {}
+
+export type PersonSelectElementProps = Partial<PersonSelectProps>;
 
 export const tag = 'fwc-person-select';
 

--- a/storybook/stories/person/person-select.stories.ts
+++ b/storybook/stories/person/person-select.stories.ts
@@ -23,13 +23,35 @@ const meta: Meta<typeof cem> = {
   decorators: [personProviderDecorator],
 };
 
-const render = (props: PersonSelectElementProps) =>
-  html`
-    <div style="min-height: 300px">
-      <fwc-person-select autofocus=${ifDefined(props.autofocus)} @select=${(e: PersonSelectEvent) =>
-        console.log('PersonSelectEvent', e)}></fwc-person-avatar>
-    </div>
-`;
+const render = (props: PersonSelectElementProps) => {
+  const selectedPerson = props.selectedPerson === null ? '' : props.selectedPerson;
+  return html`
+      <div style="min-height: 300px">
+        <fwc-person-select
+          autofocus="${ifDefined(props.autofocus)}"
+          selectedPerson=${ifDefined(selectedPerson)}
+          selectTextOnFocus=${ifDefined(props.selectTextOnFocus)}
+          disabled=${ifDefined(props.disabled)}
+          dropdownHeight=${ifDefined(props.dropdownHeight)}
+          graphic=${ifDefined(props.graphic)}
+          initialText=${ifDefined(props.initialText)}
+          label=${ifDefined(props.label)}
+          leadingIcon=${ifDefined(props.leadingIcon)}
+          meta=${ifDefined(props.meta)}
+          multiple=${ifDefined(props.multiple)}
+          placeholder=${ifDefined(props.placeholder)}
+          selectedId=${ifDefined(props.selectedId)}
+          textInputElement=${ifDefined(props.textInputElement)}
+          listElement=${ifDefined(props.listElement)}
+          value=${ifDefined(props.value)}
+          variant=${ifDefined(props.variant)}
+          @select=${(e: PersonSelectEvent) => {
+            console.log('SelectEvent', e);
+          }}
+        ></fwc-person-avatar>
+      </div>
+  `;
+};
 
 export const Default: Story = {
   args: {

--- a/storybook/stories/person/person-select.stories.ts
+++ b/storybook/stories/person/person-select.stories.ts
@@ -60,4 +60,34 @@ export const Default: Story = {
   render,
 };
 
+export const SetSelectedPersonAttributeWithUpn: Story = {
+  args: {
+    selectedPerson: 'fake@faker.info',
+  },
+  render,
+};
+
+export const SetSelectedPersonAttributeWithAzureId: Story = {
+  args: {
+    selectedPerson: '49132c24-6ea4-41fe-8221-112f314573f0',
+  },
+  render,
+};
+
+export const SetSelectedPersonAttributeWithPersonInfo: Story = {
+  args: {
+    // selectedPerson: JSON.stringify({ azureID: '49132c24-6ea4-41fe-8221-112f314573f0' }),
+    selectedPerson: '{"azureId":"49132c24-6ea4-41fe-8221-112f314573f0"}',
+  },
+  render,
+};
+
+export const ClearSelectedPersonOnSelect: Story = {
+  args: {
+    selectedPerson: null,
+  },
+  render,
+};
+
+
 export default meta;


### PR DESCRIPTION
Adds property ``selectedPerson``
Controller resolves to ``selectedPerson`` on attribute changes.
Setting ``selectedPerson`` to ``null`` will clear the ``fwc-person-select`` component after a ui selection and clear any current selections.

*extra*: adds support for node 20

Reference: [AB#47637](https://statoil-proview.visualstudio.com/3dadd756-da44-4bb3-8874-330932214dff/_workitems/edit/47637)