### PR TITLE
build: update node version to 20 + update CodeQL Action to v3

### DIFF
--- a/.github/workflows/actions/node-setup/action.yml
+++ b/.github/workflows/actions/node-setup/action.yml
@@ -1,8 +1,8 @@
 name: Setup Node
 Description: General setup of node
 inputs:
-  node-version:  
-    default: 18
+  node-version:
+    default: 20
   turbo-cache:
     default: false
 
@@ -11,14 +11,14 @@ runs:
   steps:
 
     - uses: pnpm/action-setup@v2
-    
+
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
 
     # - name: enable turbo cache
-    #   if: ${{ inputs.turbo-cache == 'true' }} 
+    #   if: ${{ inputs.turbo-cache == 'true' }}
     #   uses: dtinth/setup-github-actions-caching-for-turbo@v1
     #   with:
     #     cache-prefix: ${{ runner.os }}-node-${{ inputs.node-version }}_
@@ -26,4 +26,3 @@ runs:
     - name: install
       shell: bash
       run: pnpm install
-        

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Fix #979

Ref: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/
Ref: https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/