### PR TITLE
chore(dependabot): update dependabot actions directory to "/"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 50
   - package-ecosystem: "github-actions"
-    directory: "/.github/"
+    directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"


### PR DESCRIPTION
`Set the directory to "/" to check for workflow files in .github/workflows`.
Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot