### PR TITLE
fix(person): personselect should now clear on setting selectedPerson …

### DIFF
--- a/.changeset/two-carrots-marry.md
+++ b/.changeset/two-carrots-marry.md
@@ -1,0 +1,13 @@
+---
+"@equinor/fusion-wc-person": patch
+---
+
+### Changes in `PersonSelectController`
+
+- Renamed the `attrSelectPerson` method to `attrSelectedPerson`.
+- Updated the `attrSelectedPerson` method to clear `selectedIds` when `select` is null or an empty string and `selectedIds` size is greater than zero.
+- Added logic to clear previous selections when the `selectedPerson` property changes.
+
+### Changes in `PersonSelectElement`
+
+- Updated the `updated` method to call `attrSelectedPerson` instead of `attrSelectPerson`.

--- a/packages/person/src/components/select/controller.ts
+++ b/packages/person/src/components/select/controller.ts
@@ -54,11 +54,19 @@ export class PersonSelectController implements ReactiveController {
    * Resolve personInfo task from selectedPerson property.
    * Runs on host updated when property is changed
    */
-  public attrSelectPerson(select: string | null | undefined) {
-    /* Do not trigger task if undefined or null */
+  public attrSelectedPerson(select: string | null | undefined) {
+    if ((select === null || select === '') && this.selectedIds.size) {
+      this.clear();
+      return;
+    }
+
+    /* Do not trigger task if undefined */
     if (!select) {
       return;
     }
+
+    // clear previous selections since property has changed
+    this.selectedIds.clear();
 
     /* Trigger PersonInfo task with upn or azureId */
     if (select.match('@')) {

--- a/packages/person/src/components/select/element.ts
+++ b/packages/person/src/components/select/element.ts
@@ -168,7 +168,7 @@ export class PersonSelectElement
 
   updated(props: Map<string, string | null | undefined>) {
     if (props.has('selectedPerson')) {
-      this.controllers.element.attrSelectPerson(
+      this.controllers.element.attrSelectedPerson(
         this.selectedPerson?.upn ?? this.selectedPerson?.azureId ?? (this.selectedPerson as null | undefined),
       );
     }


### PR DESCRIPTION

### Changes in `PersonSelectController`

- Renamed the `attrSelectPerson` method to `attrSelectedPerson`.
- Updated the `attrSelectedPerson` method to clear `selectedIds` when `select` is null or an empty string and `selectedIds` size is greater than zero.
- Added logic to clear previous selections when the `selectedPerson` property changes.

### Changes in `PersonSelectElement`

- Updated the `updated` method to call `attrSelectedPerson` instead of `attrSelectPerson`.