### PR TITLE
fix(person-select): adding html attribute name for selectedPerson

### DIFF
--- a/.changeset/empty-jars-attack.md
+++ b/.changeset/empty-jars-attack.md
@@ -1,0 +1,7 @@
+---
+"@equinor/fusion-wc-person": patch
+---
+
+### Changes in `PersonSelectElement`
+
+- Added the `attribute: 'selectedperson'` to the `selectedPerson` property config to fix use in react and as a legal html property name.

--- a/packages/person/src/components/select/element.ts
+++ b/packages/person/src/components/select/element.ts
@@ -127,6 +127,7 @@ export class PersonSelectElement
   search = '';
 
   @property({
+    attribute: 'selectedperson',
     converter(value) {
       /* converter to allow user to pass personobject as property */
       if (value?.length) {


### PR DESCRIPTION
### Changes in `PersonSelectElement`

- Added the `attribute: 'selected-person'` to the `selectedPerson` property config to fix use in react and as a legal html property name.
