### PR TITLE
Fix missing super call in TextInputElement's firstUpdated method

### DIFF
--- a/.changeset/dry-hairs-occur.md
+++ b/.changeset/dry-hairs-occur.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-wc-textinput': patch
+---
+
+Resolved an issue where the `TextInputElement.firstUpdated` method did not call `super`, preventing the MDC foundation from initializing properly.

--- a/packages/textinput/src/element.ts
+++ b/packages/textinput/src/element.ts
@@ -167,6 +167,7 @@ export class TextInputElement extends TextFieldBase {
 
   firstUpdated(): void {
     this.formElement.autocomplete = this.autocomplete;
+    super.firstUpdated();
   }
 
   /** {@inheritDoc} */

--- a/packages/textinput/src/element.ts
+++ b/packages/textinput/src/element.ts
@@ -166,8 +166,8 @@ export class TextInputElement extends TextFieldBase {
   }
 
   firstUpdated(): void {
-    this.formElement.autocomplete = this.autocomplete;
     super.firstUpdated();
+    this.formElement.autocomplete = this.autocomplete;
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
Resolve an issue where the `firstUpdated` method did not call `super`, preventing proper initialization of the MDC foundation.