### PR TITLE
chore(workflows): add `--frozen-lockfile` to `pnpm install`

### DIFF
--- a/.github/workflows/actions/node-setup/action.yml
+++ b/.github/workflows/actions/node-setup/action.yml
@@ -25,4 +25,4 @@ runs:
 
     - name: install
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This PR adds the --frozen-lockfile flag to the pnpm install command in the GitHub workflow node setup action to ensure deterministic builds by preventing lockfile modifications during CI/CD processes.