### PR TITLE
feat: improve text wrapping for person card department/job title fields

### DIFF
--- a/.changeset/improved-text-wrapping.md
+++ b/.changeset/improved-text-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-wc-person": patch
+---
+
+Improve text wrapping for department and job title fields in person card by adding word-break, overflow-wrap, and hyphens properties.

--- a/packages/person/src/components/card/element.css.ts
+++ b/packages/person/src/components/card/element.css.ts
@@ -83,7 +83,9 @@ const style: CSSResult = css`
   }
   .person-card__department,
   .person-card__jobtitle {
-    white-space: break-spaces;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
     font-size: calc(
       ${unsafeCSS(theme.typography.paragraph.caption.getVariable("fontSize"))} * var(--content-resize, 1)
     );


### PR DESCRIPTION
Improve text wrapping for department and job title fields in person card by adding word-break, overflow-wrap, and hyphens properties.