### PR TITLE
chore: disable source map generation in build

### DIFF
--- a/.changeset/remove-sourcemaps.md
+++ b/.changeset/remove-sourcemaps.md
@@ -1,0 +1,33 @@
+---
+'@equinor/fusion-web-components': patch
+'@equinor/fusion-wc-avatar': patch
+'@equinor/fusion-wc-badge': patch
+'@equinor/fusion-wc-button': patch
+'@equinor/fusion-wc-checkbox': patch
+'@equinor/fusion-wc-chip': patch
+'@equinor/fusion-wc-core': patch
+'@equinor/fusion-wc-date': patch
+'@equinor/fusion-wc-divider': patch
+'@equinor/fusion-wc-formfield': patch
+'@equinor/fusion-wc-icon': patch
+'@equinor/fusion-wc-intersection': patch
+'@equinor/fusion-wc-list': patch
+'@equinor/fusion-wc-markdown': patch
+'@equinor/fusion-wc-menu': patch
+'@equinor/fusion-wc-people': patch
+'@equinor/fusion-wc-person': patch
+'@equinor/fusion-wc-picture': patch
+'@equinor/fusion-wc-popover': patch
+'@equinor/fusion-wc-progress-indicator': patch
+'@equinor/fusion-wc-radio': patch
+'@equinor/fusion-wc-ripple': patch
+'@equinor/fusion-wc-searchable-dropdown': patch
+'@equinor/fusion-wc-select': patch
+'@equinor/fusion-wc-skeleton': patch
+'@equinor/fusion-wc-switch': patch
+'@equinor/fusion-wc-textarea': patch
+'@equinor/fusion-wc-textinput': patch
+'@equinor/fusion-wc-theme': patch
+---
+
+Remove source maps from build output. Source maps were included in packages but referenced source files that were excluded from npm, making them broken and adding unnecessary size.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "lib": ["esnext", "dom"],
     "types": ["react"],
     "declaration": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Summary

Disables source map generation by setting `sourceMap: false` in `tsconfig.base.json`.

## Problem

Source maps (`.js.map` files) were being generated and included in published npm packages, but the source files (`src/`) they reference were excluded via `.npmignore`. This resulted in:

- Broken source maps that point to non-existent files
- Unnecessary package size (~222 `.js.map` files across packages)

## Change

- Set `"sourceMap": false` in `tsconfig.base.json`

## References

- https://github.com/equinor/fusion-core-tasks/issues/983
- https://github.com/equinor/fusion/issues/391
- https://github.com/equinor/fusion/issues/825