### PR TITLE
fix(person): vertically center table-cell text with avatar

### DIFF
--- a/.changeset/person-table-cell-alignment.md
+++ b/.changeset/person-table-cell-alignment.md
@@ -1,0 +1,5 @@
+---
+'@equinor/fusion-wc-person': patch
+---
+
+Fix `fwc-person-table-cell` heading/subheading vertical alignment. Removed the `padding-bottom` on `.person-cell__content` that pushed the text block ~4px above the avatar's center, so the name is now truly vertically centered with the avatar and aligns with sibling text when used inside an EDS `Table.Cell`. Fixes equinor/fusion#837.

--- a/packages/person/src/components/table-cell/element.css.ts
+++ b/packages/person/src/components/table-cell/element.css.ts
@@ -36,7 +36,6 @@ const style: CSSResult = css`
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding-bottom: 4px;
   }
   .person-cell__content-gap {
     row-gap: ${unsafeCSS(theme.spacing.comfortable.x_small.getVariable('padding'))};

--- a/storybook/stories/person/person-table-cell.stories.ts
+++ b/storybook/stories/person/person-table-cell.stories.ts
@@ -56,4 +56,43 @@ export const Sizes: Story = {
       )}`,
 };
 
+/**
+ * Regression story for equinor/fusion#837.
+ *
+ * Places `<fwc-person-table-cell>` inside a table row next to a plain-text cell
+ * (mirroring usage inside an EDS `Table.Cell`) so the heading text alignment
+ * against sibling text is visible. The heading should be vertically centered
+ * with the avatar and align with the adjacent plain-text cell across all sizes.
+ */
+export const TableAlignment: Story = {
+  render: () => html`
+    <table style="border-collapse: collapse; width: 100%;">
+      <thead>
+        <tr style="text-align: left; border-bottom: 1px solid #dcdcdc;">
+          <th style="padding: 8px;">Person</th>
+          <th style="padding: 8px;">Department</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${(['small', 'medium', 'large'] as PersonTableCellElementProps['size'][]).map(
+          (size) => html`
+            <tr style="border-bottom: 1px solid #dcdcdc;">
+              <td style="padding: 8px; vertical-align: middle;">
+                <fwc-person-table-cell
+                  size="${ifDefined(size)}"
+                  azureId=${faker.string.uuid()}
+                  .heading=${(person: TableCellData) => person.name}
+                  .subHeading=${(person: TableCellData) => person.jobTitle}
+                  showAvatar
+                />
+              </td>
+              <td style="padding: 8px; vertical-align: middle;">${faker.commerce.department()}</td>
+            </tr>
+          `,
+        )}
+      </tbody>
+    </table>
+  `,
+};
+
 export default meta;


### PR DESCRIPTION
## Description

The `<fwc-person-table-cell>` web component rendered its heading/subheading text aligned toward the top of the avatar instead of vertically centered. When placed inside an EDS `Table.Cell` next to plain-text cells, the name sat ~4px higher than the surrounding text.

### Root cause

`.person-cell__content` carried a `padding-bottom: 4px`. The parent `.person-cell__about` uses `align-items: center` to center the text block against the avatar, so that bottom padding was included in the centered box and pushed the visible text above the true center.

### Fix

- Removed `padding-bottom: 4px` from `.person-cell__content` in `packages/person/src/components/table-cell/element.css.ts`. The heading/subheading row-gap comes from `.person-cell__content-gap`, not this padding, so spacing is unchanged.
- Verified centering holds for `small` / `medium` / `large` — those sizes only scale font-size/line-height via `--text-resize`; centering is handled by flexbox.

### Regression coverage

Added a `TableAlignment` Storybook story that renders the component in a table row next to a plain-text cell (mirroring EDS `Table.Cell` usage) across all three sizes, so misalignment against sibling text is visible going forward.

## Checklist

- [x] Package builds (`pnpm --filter @equinor/fusion-wc-person build`)
- [x] Lint passes (`pnpm lint`)
- [x] Storybook builds (`pnpm build:docs`)
- [x] Changeset added (`@equinor/fusion-wc-person`, patch)

Fixes equinor/fusion#837