### PR TITLE
Fix/personpicker/table header

### DIFF
--- a/.changeset/people_picker_table_view.md
+++ b/.changeset/people_picker_table_view.md
@@ -1,0 +1,9 @@
+---
+'@equinor/fusion-wc-people': minor
+---
+
+Add table view story for people picker component and refine table cell styling.
+
+- Added new `tableView` story demonstrating the people picker with table display mode
+- Adjusted CSS selectors for table rows to target `tbody` specifically
+- Updated avatar column width from 60px to 66px for better visual alignment

--- a/.changeset/people_picker_table_view.md
+++ b/.changeset/people_picker_table_view.md
@@ -1,5 +1,5 @@
 ---
-'@equinor/fusion-wc-people': minor
+'@equinor/fusion-wc-people': patch
 ---
 
 Add table view story for people picker component and refine table cell styling.

--- a/packages/people/src/components/base/element.css.ts
+++ b/packages/people/src/components/base/element.css.ts
@@ -96,7 +96,7 @@ export const peopleBaseStyle: CSSResult = css`
     background-color: ${unsafeCSS(theme.colors.ui.background__light.getVariable('color'))};
   }
 
-  table tr .name {
+  table tbody tr .name {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
@@ -112,7 +112,7 @@ export const peopleBaseStyle: CSSResult = css`
   
   table tr .avatar,
   table tr .remove {
-    width: 60px;
+    width: 66px;
     text-align: center;
     padding: ${unsafeCSS(theme.spacing.comfortable.small.getVariable('padding'))};
   }

--- a/storybook/stories/person/people/people-picker.stories.ts
+++ b/storybook/stories/person/people/people-picker.stories.ts
@@ -92,9 +92,7 @@ export const resolveIds: Story = {
 };
 
 export const people: Story = {
-  args: {
-    multiple: true,
-  },
+  args: {},
   loaders: [
     async () => {
       const resolvedPeople = await Promise.all(
@@ -108,6 +106,35 @@ export const people: Story = {
       multiple=${ifDefined(props.multiple)}
       resolveids=${ifDefined(props.resolveIds)}
       people=${JSON.stringify(resolvedPeople)}
+      showselectedpeople=${ifDefined(props.showSelectedPeople)}
+      subtitle=${ifDefined(props.subtitle)}
+      secondarysubtitle=${ifDefined(props.secondarySubtitle)}
+      placeholder=${ifDefined(props.placeholder)}
+      @selection-changed=${handleSelectionChanged}
+      @person-added=${handlePersonAdded}
+      @person-removed=${handlePersonRemoved}>
+    </fwc-people-picker>
+  `,
+};
+
+export const tableView: Story = {
+  args: {
+    display: 'table',
+  },
+  loaders: [
+    async () => {
+      const resolvedPeople = await Promise.all(
+        generateIds(5, 10).map((azureId) => generatePerson({ azureId })),
+      );
+      return { resolvedPeople };
+    },
+  ],
+  render: (props: PeoplePickerElementProps, { loaded: { resolvedPeople } }) => html`
+    <fwc-people-picker
+      multiple=${ifDefined(props.multiple)}
+      resolveids=${ifDefined(props.resolveIds)}
+      people=${JSON.stringify(resolvedPeople)}
+      display=${ifDefined(props.display)}
       showselectedpeople=${ifDefined(props.showSelectedPeople)}
       subtitle=${ifDefined(props.subtitle)}
       secondarysubtitle=${ifDefined(props.secondarySubtitle)}


### PR DESCRIPTION
Add table view story for people picker component and refine table cell styling.

- Added new `tableView` story demonstrating the people picker with table display mode
- Adjusted CSS selectors for table rows to target `tbody` specifically
- Updated avatar column width from 60px to 66px for better visual alignment