### PR TITLE
fix(people): update resolveids to merge selections and trigger change…

### DIFF
--- a/.changeset/wild-eyes-marry.md
+++ b/.changeset/wild-eyes-marry.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-wc-people": patch
+---
+
+Fix `resolveids` on people picker so resolved people are added to the existing selection instead of replacing it. This makes `resolveids` trigger the expected change events, with `selection-changed` reflecting the merged set of people.

--- a/packages/people/src/controllers/ResolvedController.ts
+++ b/packages/people/src/controllers/ResolvedController.ts
@@ -73,7 +73,7 @@ export class ResolvedController implements ReactiveController {
 
     if (hasChanged) {
       // sync resolved people to selected people
-      selected.setSelectedPeople(resolvedPeople);
+      selected.addPeople(resolvedPeople);
 
       // set flag to true to prevent re-parsing on next update
       this.#host.parsedResolved = true;

--- a/storybook/stories/person/people/people-viewer.stories.ts
+++ b/storybook/stories/person/people/people-viewer.stories.ts
@@ -70,7 +70,6 @@ const renderConnected = (props: PeoplePickerElementProps & PeopleViewerElementPr
   };
 
   const handleSelectionChanged = (e: SelectionChangedEvent) => {
-    console.log('fwc-people-viewer::selection-changed', e.detail);
     people = [...e.detail];
 
     setPropPeople(people);
@@ -82,8 +81,7 @@ const renderConnected = (props: PeoplePickerElementProps & PeopleViewerElementPr
 
       <fwc-people-picker
         id="people-picker"
-        multiple"false"
-        showselectedpeople="false"
+        resolveids=${generateIds(3, 12).join(',')}
         @person-added=${handlePersonAdded}
         @person-removed=${handlePersonRemoved}
         style="margin-bottom: 1em;">
@@ -92,7 +90,6 @@ const renderConnected = (props: PeoplePickerElementProps & PeopleViewerElementPr
       <fwc-people-viewer
         id="people-viewer"
         people=${JSON.stringify(people)}
-        resolveids=${generateIds(3, 12).join(',')}
         @selection-changed=${handleSelectionChanged}
       >
       </fwc-people-viewer>


### PR DESCRIPTION
**@equinor/fusion-wc-people**

Fix `resolveids` on people picker so resolved people are added to the existing selection instead of replacing it. This makes `resolveids` trigger the expected change events, with `selection-changed` reflecting the merged set of people.