### PR TITLE
feat(searchable-dropdown): add opt-in top-layer rendering for result list

### DIFF
--- a/.changeset/searchable-dropdown-top-layer.md
+++ b/.changeset/searchable-dropdown-top-layer.md
@@ -1,0 +1,5 @@
+---
+"@equinor/fusion-wc-searchable-dropdown": minor
+---
+
+Add opt-in `topLayer` property (`top-layer` attribute) to `fwc-searchable-dropdown`. When enabled, the result list renders in the browser's top layer via the native Popover API (`popover="manual"`) instead of a shadow-DOM-relative, absolutely positioned box, so it can reliably appear above content that creates its own independent stacking context elsewhere in the app (e.g. a portal header, dialog, or any ancestor with `transform`/`filter`/`contain`/`z-index`). Opening/closing stays driven by the existing controller, and outside-click/Escape handling is unchanged. The result surface is repositioned on window resize and ancestor scroll. Falls back automatically to the previous behavior in browsers without Popover API support. Default behavior for existing consumers is unchanged (`topLayer` defaults to `false`).

--- a/packages/searchable-dropdown/README.md
+++ b/packages/searchable-dropdown/README.md
@@ -16,3 +16,35 @@
 SearchableDropdown renders a searchable dynamic proved by the resolver.
 
 Note, fwc-searchable-dropdown internally uses: [fwc-textinput](https://equinor.github.io/fusion-web-components/?path=/docs/input-textinput) and [fwc-list](https://equinor.github.io/fusion-web-components/?path=/docs/data-list).
+
+### Rendering the result list above arbitrary stacking contexts
+
+By default, the result list is an absolutely positioned box anchored inside the
+component's shadow root, stacked with `z-index: 99`. This works for most cases,
+but a plain `z-index` can never guarantee precedence over an independently
+created stacking context elsewhere in the page (e.g. a portal app header, a
+dialog, or any ancestor using `transform`/`filter`/`contain`).
+
+Set the `top-layer` attribute (`topLayer` property) to opt in to rendering the
+result list in the browser's [top layer](https://developer.mozilla.org/docs/Glossary/Top_layer)
+via the native [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API)
+(`popover="manual"`). The top layer always paints above the regular document,
+regardless of ancestor stacking contexts, so this avoids a z-index arms race
+entirely.
+
+```html
+<fwc-searchable-dropdown-provider>
+  <fwc-searchable-dropdown top-layer></fwc-searchable-dropdown>
+</fwc-searchable-dropdown-provider>
+```
+
+- Opening/closing remains fully driven by the existing controller; the
+  browser's own light-dismiss behavior is disabled (`popover="manual"`), so
+  outside-click and Escape handling is unchanged.
+- The result surface stays anchored to the input on window resize and on
+  scroll of any ancestor scroll container.
+- Falls back automatically to the default behavior in browsers without
+  Popover API support (Chrome/Edge 114+, Firefox 125+, Safari 17+ - see
+  [caniuse](https://caniuse.com/mdn-api_htmlelement_showpopover)).
+- Default behavior is unchanged for existing consumers (`topLayer` defaults to
+  `false`).

--- a/packages/searchable-dropdown/src/dropdown/element.css.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.css.ts
@@ -59,6 +59,27 @@ export const fwcsdd: CSSResult = css`
       0px 2px 4px rgba(0, 0, 0, 0.14);
     border-radius: 4px;
   }
+  /**
+   * Top-layer mode (topLayer property, popover="manual"): the browser's UA
+   * stylesheet promotes this element to the top layer and makes it
+   * position: fixed, so it must be re-anchored to the viewport instead of
+   * the shadow-DOM-relative host. Position/size is computed and applied
+   * inline by the element (see #updatePopoverPosition); this only resets
+   * the UA defaults (border/padding/background/margin/inset) that would
+   * otherwise fight our own box-shadow/border-radius styling above.
+   */
+  .list[popover] {
+    position: fixed;
+    inset: auto;
+    top: 0;
+    left: 0;
+    margin: 0;
+    padding: 0;
+    border: none;
+    overflow: hidden;
+    background: transparent;
+    color: inherit;
+  }
   .list-scroll {
     width: 100%;
     height: auto;

--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -1,6 +1,7 @@
 import {
   html,
   LitElement,
+  nothing,
   type HTMLTemplateResult,
   type CSSResult,
   type PropertyValues,
@@ -37,6 +38,14 @@ IconElement;
 import { sddStyles } from './element.css';
 
 /**
+ * Feature-detects browser support for the Popover API (top layer rendering).
+ * Evaluated once per module load since support does not change at runtime.
+ * @see https://caniuse.com/mdn-api_htmlelement_showpopover
+ */
+const SUPPORTS_POPOVER: boolean =
+  typeof HTMLElement !== 'undefined' && typeof HTMLElement.prototype.showPopover === 'function';
+
+/**
  * Element for SearchableDropdown
  * @tag fwc-searchable-dropdown
  *
@@ -56,6 +65,7 @@ import { sddStyles } from './element.css';
  * @property {string} multiple Able to select multiple items
  * @property {string} placeholder Placeholder text for fwc-textinput element
  * @property {string} selectedId ID that should be selected
+ * @property {boolean} topLayer Render the result list in the browser's top layer via the Popover API instead of a shadow-DOM-relative absolutely positioned box. Opt-in, defaults to false.
  * @property {string} value value for TextInput element
  * @property {'page' | 'page-outlined' | 'page-dense' | 'header' | 'header-filled'} variant Set variant to header|page style
  *
@@ -135,19 +145,143 @@ export class SearchableDropdownElement
   @property({ type: Boolean, attribute: 'select-text-on-focus', reflect: true })
   selectTextOnFocus = false;
 
+  /**
+   * Render the result list in the browser's top layer using the native
+   * [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API)
+   * (`popover="manual"`) instead of a shadow-DOM-relative, `position:
+   * absolute` box.
+   *
+   * Enable this when the result list must reliably render above content
+   * that creates its own independent stacking context elsewhere in the host
+   * application (e.g. a portal app header, a dialog, or any ancestor with
+   * `transform`/`filter`/`contain`/`z-index`). Ordinary z-index cannot
+   * guarantee precedence over such stacking contexts because it is only
+   * ever compared *within* the nearest containing stacking context - the
+   * top layer paints above the entire document regardless of ancestors.
+   *
+   * The result surface remains anchored to the input and is repositioned on
+   * window resize and on scroll of any ancestor scroll container while
+   * open. Opening/closing stays fully driven by
+   * {@link SearchableDropdownController.isOpen}; outside-click and Escape
+   * handling is unchanged since `popover="manual"` disables the browser's
+   * own light-dismiss behavior.
+   *
+   * Automatically falls back to the default (non-top-layer) behavior in
+   * browsers without Popover API support - see
+   * https://caniuse.com/mdn-api_htmlelement_showpopover.
+   *
+   * @attr top-layer
+   */
+  @property({ type: Boolean, attribute: 'top-layer', reflect: true })
+  topLayer = false;
+
   @query('fwc-textinput')
   textInputElement: TextInputElement | undefined;
 
   @query('fwc-list')
   listElement: ListElement | undefined;
 
+  @query('.list')
+  protected listSurfaceElement?: HTMLDivElement;
+
   @state()
   selectedItems: Set<SearchableDropdownResultItem['id']> = new Set([]);
+
+  /**
+   * Tracks whether the top-layer popover is currently shown, so we only call
+   * `showPopover()`/`hidePopover()` when the state actually transitions.
+   */
+  #popoverOpen = false;
+
+  /**
+   * @returns true when top-layer mode is both requested and supported by
+   * the current browser.
+   */
+  protected get isTopLayerActive(): boolean {
+    return this.topLayer && SUPPORTS_POPOVER;
+  }
 
   updated(props: PropertyValues) {
     if (props.has('selectedId')) {
       this.controller.updateSelectedByProp();
     }
+
+    /* if top-layer mode was just disabled while the popover was showing, tear it down */
+    if (props.has('topLayer') && !this.isTopLayerActive && this.#popoverOpen) {
+      this.#popoverOpen = false;
+      this.#detachPositionListeners();
+    }
+
+    if (this.isTopLayerActive) {
+      this.#syncPopover();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#detachPositionListeners();
+  }
+
+  /**
+   * Shows/hides the top-layer popover to match the controller's open state,
+   * (re)computing its anchored position and (de)registering the listeners
+   * that keep it anchored while open.
+   */
+  #syncPopover(): void {
+    const el = this.listSurfaceElement;
+    if (!el) {
+      return;
+    }
+
+    const shouldBeOpen = this.controller.isOpen;
+    if (shouldBeOpen === this.#popoverOpen) {
+      return;
+    }
+    this.#popoverOpen = shouldBeOpen;
+
+    if (shouldBeOpen) {
+      this.#updatePopoverPosition();
+      try {
+        el.showPopover();
+      } catch {
+        /* already open, or not yet connected - ignore */
+      }
+      this.#attachPositionListeners();
+    } else {
+      try {
+        el.hidePopover();
+      } catch {
+        /* already closed - ignore */
+      }
+      this.#detachPositionListeners();
+    }
+  }
+
+  /**
+   * Anchors the popover to the current position/size of the host, since
+   * top-layer content is taken out of normal flow and positioned relative
+   * to the viewport.
+   */
+  #updatePopoverPosition = (): void => {
+    const el = this.listSurfaceElement;
+    if (!el) {
+      return;
+    }
+    const rect = this.getBoundingClientRect();
+    el.style.left = `${rect.left}px`;
+    el.style.top = `${rect.bottom + 4}px`;
+    el.style.width = `${rect.width}px`;
+  };
+
+  #attachPositionListeners(): void {
+    window.addEventListener('resize', this.#updatePopoverPosition);
+    /* scroll events don't bubble, but they do reach a capturing window listener */
+    window.addEventListener('scroll', this.#updatePopoverPosition, true);
+  }
+
+  #detachPositionListeners(): void {
+    window.removeEventListener('resize', this.#updatePopoverPosition);
+    window.removeEventListener('scroll', this.#updatePopoverPosition, true);
   }
 
   /* Build fwc-list-items */
@@ -355,7 +489,7 @@ export class SearchableDropdownElement
             <span slot="trailing">${this.renderCloseIcon()} </span>
           </slot>
         </div>
-        <div class="list">
+        <div class="list" popover=${this.isTopLayerActive ? 'manual' : nothing}>
           <div class="list-scroll">${this.renderList()}</div>
         </div>
       </div>

--- a/packages/searchable-dropdown/src/dropdown/element.ts
+++ b/packages/searchable-dropdown/src/dropdown/element.ts
@@ -206,10 +206,9 @@ export class SearchableDropdownElement
       this.controller.updateSelectedByProp();
     }
 
-    /* if top-layer mode was just disabled while the popover was showing, tear it down */
-    if (props.has('topLayer') && !this.isTopLayerActive && this.#popoverOpen) {
-      this.#popoverOpen = false;
-      this.#detachPositionListeners();
+    /* revert to default positioning whenever top-layer mode is turned off */
+    if (props.has('topLayer') && !this.isTopLayerActive) {
+      this.#teardownPopover();
     }
 
     if (this.isTopLayerActive) {
@@ -255,6 +254,37 @@ export class SearchableDropdownElement
       }
       this.#detachPositionListeners();
     }
+  }
+
+  /**
+   * Reverts the result list back to its default, shadow-DOM-relative
+   * absolute positioning. Called whenever top-layer mode is turned off, so
+   * neither a lingering top-layer popover state nor the inline
+   * `top`/`left`/`width` styles set by {@link #updatePopoverPosition} for
+   * viewport-relative anchoring stick around and mis-position (or
+   * mis-stack) the list once it falls back to `position: absolute`.
+   *
+   * Always runs the cleanup unconditionally rather than only when
+   * {@link #popoverOpen} is currently true, since the popover may have
+   * already been closed (e.g. via a prior selection) while those inline
+   * styles were still left on the element from when it was last shown.
+   */
+  #teardownPopover(): void {
+    this.#popoverOpen = false;
+    this.#detachPositionListeners();
+
+    const el = this.listSurfaceElement;
+    if (!el) {
+      return;
+    }
+    try {
+      el.hidePopover();
+    } catch {
+      /* already hidden - e.g. the browser auto-hides on popover attribute removal - ignore */
+    }
+    el.style.removeProperty('top');
+    el.style.removeProperty('left');
+    el.style.removeProperty('width');
   }
 
   /**

--- a/packages/searchable-dropdown/src/types.ts
+++ b/packages/searchable-dropdown/src/types.ts
@@ -16,6 +16,7 @@ import type { IconElement, IconType } from '@equinor/fusion-wc-icon';
  * @placeholder TextInput placeholder
  * @selectedId Preselected item id
  * @textInputElement the html node of input
+ * @topLayer Render the result list in the browser top layer (Popover API) so it can appear above independently created stacking contexts. Falls back to default positioning when unsupported.
  * @value The preselected value. shoudl be combined with value
  * @variant Set variant to 'page' | 'page-outlined' | 'page-dense' | 'header' | 'header-filled'
  */
@@ -34,6 +35,7 @@ export interface SearchableDropdownProps {
   selectedId?: string;
   textInputElement?: TextInputElement;
   listElement?: ListElement;
+  topLayer?: boolean;
   value?: string;
   variant?: string;
 }

--- a/storybook/stories/input/searchable-dropdown.stories.ts
+++ b/storybook/stories/input/searchable-dropdown.stories.ts
@@ -79,7 +79,7 @@ export const SelectTextOnFocus: Story = {
  */
 export const TopLayer: Story = {
   ...Default,
-  args: { topLayer: true },
+  args: { topLayer: false },
   render: (props) => html`
     <div
       style="position: relative; transform: translateZ(0); padding: 2rem 1rem 260px; border: 1px dashed gray;"

--- a/storybook/stories/input/searchable-dropdown.stories.ts
+++ b/storybook/stories/input/searchable-dropdown.stories.ts
@@ -82,7 +82,7 @@ export const TopLayer: Story = {
   args: { topLayer: true, initialText: 'Try me - open above the red overlay' },
   render: (props) => html`
     <div
-      style="position: relative; transform: translateZ(0); padding: 2rem 1rem 6rem; border: 1px dashed gray;"
+      style="position: relative; transform: translateZ(0); padding: 2rem 1rem 260px; border: 1px dashed gray;"
     >
       <p style="margin: 0 0 1rem; font: 0.85rem/1.4 sans-serif;">
         This box creates its own stacking context via

--- a/storybook/stories/input/searchable-dropdown.stories.ts
+++ b/storybook/stories/input/searchable-dropdown.stories.ts
@@ -33,6 +33,7 @@ const render = (props: SearchableDropdownProps) => html`
     multiple="${ifDefined(props.multiple)}"
     selectedId="${ifDefined(props.selectedId)}"
     select-text-on-focus="${ifDefined(props.selectTextOnFocus)}"
+    top-layer="${ifDefined(props.topLayer)}"
   ></fwc-searchable-dropdown>
 `;
 
@@ -64,6 +65,39 @@ export const Multiple: Story = {
 export const SelectTextOnFocus: Story = {
   ...Default,
   render: (props) => render({ ...props, selectTextOnFocus: true }),
+};
+
+/**
+ * Demonstrates `topLayer` mode. The dropdown is nested inside a box that
+ * creates its own stacking context (`transform: translateZ(0)`), and a red
+ * overlay inside that same box uses `z-index: 999`. With the default
+ * behavior an absolutely positioned, shadow-DOM-relative result list can
+ * never escape that stacking context - no z-index on the dropdown could
+ * beat it. With `topLayer` enabled, the result list renders in the
+ * browser's top layer and appears above the overlay regardless of its
+ * z-index.
+ */
+export const TopLayer: Story = {
+  ...Default,
+  args: { topLayer: true, initialText: 'Try me - open above the red overlay' },
+  render: (props) => html`
+    <div
+      style="position: relative; transform: translateZ(0); padding: 2rem 1rem 6rem; border: 1px dashed gray;"
+    >
+      <p style="margin: 0 0 1rem; font: 0.85rem/1.4 sans-serif;">
+        This box creates its own stacking context via
+        <code>transform: translateZ(0)</code>. The overlay below sits inside
+        it with <code>z-index: 999</code>. Toggle
+        <strong>topLayer</strong> in the Controls panel to compare.
+      </p>
+      ${render(props)}
+      <div
+        style="position: absolute; inset: 80px 0 0; z-index: 999; background: rgba(226, 6, 44, 0.25); font: 0.85rem/1.4 sans-serif; text-align: center; padding-top: 0.5rem;"
+      >
+        Overlay with its own stacking context (z-index: 999)
+      </div>
+    </div>
+  `,
 };
 
 export default meta;

--- a/storybook/stories/input/searchable-dropdown.stories.ts
+++ b/storybook/stories/input/searchable-dropdown.stories.ts
@@ -79,7 +79,7 @@ export const SelectTextOnFocus: Story = {
  */
 export const TopLayer: Story = {
   ...Default,
-  args: { topLayer: true, initialText: 'Try me - open above the red overlay' },
+  args: { topLayer: true },
   render: (props) => html`
     <div
       style="position: relative; transform: translateZ(0); padding: 2rem 1rem 260px; border: 1px dashed gray;"

--- a/storybook/stories/input/searchable-dropdown.stories.ts
+++ b/storybook/stories/input/searchable-dropdown.stories.ts
@@ -86,15 +86,18 @@ export const TopLayer: Story = {
     >
       <p style="margin: 0 0 1rem; font: 0.85rem/1.4 sans-serif;">
         This box creates its own stacking context via
-        <code>transform: translateZ(0)</code>. The overlay below sits inside
-        it with <code>z-index: 999</code>. Toggle
-        <strong>topLayer</strong> in the Controls panel to compare.
+        <code>transform: translateZ(0)</code>. The overlay directly below the
+        input sits inside it with <code>z-index: 999</code> - exactly where
+        the result list would open. Toggle <strong>topLayer</strong> in the
+        Controls panel to compare.
       </p>
-      ${render(props)}
-      <div
-        style="position: absolute; inset: 80px 0 0; z-index: 999; background: rgba(226, 6, 44, 0.25); font: 0.85rem/1.4 sans-serif; text-align: center; padding-top: 0.5rem;"
-      >
-        Overlay with its own stacking context (z-index: 999)
+      <div style="position: relative;">
+        ${render(props)}
+        <div
+          style="position: absolute; top: 100%; left: 0; right: 0; height: 200px; z-index: 999; background: rgba(226, 6, 44, 0.25); font: 0.85rem/1.4 sans-serif; text-align: center; padding-top: 0.5rem;"
+        >
+          Overlay with its own stacking context (z-index: 999)
+        </div>
       </div>
     </div>
   `,

--- a/storybook/stories/input/searchable-dropdown.stories.ts
+++ b/storybook/stories/input/searchable-dropdown.stories.ts
@@ -33,7 +33,7 @@ const render = (props: SearchableDropdownProps) => html`
     multiple="${ifDefined(props.multiple)}"
     selectedId="${ifDefined(props.selectedId)}"
     select-text-on-focus="${ifDefined(props.selectTextOnFocus)}"
-    top-layer="${ifDefined(props.topLayer)}"
+    ?top-layer="${props.topLayer}"
   ></fwc-searchable-dropdown>
 `;
 


### PR DESCRIPTION
## Summary

Implements the low-level half of equinor/fusion-core-tasks#1428: portal-owned context selector results need to render above arbitrary Fusion app stacking contexts, without a z-index arms race.

Adds an opt-in `topLayer` property (`top-layer` attribute) to `SearchableDropdownElement` (`@equinor/fusion-wc-searchable-dropdown`). When enabled, the result list is promoted to the browser's **top layer** via the native [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) (`popover="manual"`), instead of being an absolutely positioned box (`z-index: 99`) anchored inside the component's shadow root.

Ordinary z-index can never guarantee precedence over an independently created stacking context (e.g. `transform`/`filter`/`contain` on an ancestor) because it is only ever compared *within* the nearest containing stacking context. The top layer paints above the entire document regardless of ancestors, which is the standards-based fix for this class of problem.

## Why `popover="manual"`

`manual` disables the browser's own light-dismiss/auto-close behavior, so:
- Opening/closing stays fully driven by the existing `SearchableDropdownController.isOpen` state.
- Outside-click and Escape handling continue to go through the component's existing `document.body` listeners, unchanged.
- No double-handling/race between browser auto-dismiss and the component's own logic.

## Positioning

Because top-layer content is taken out of normal flow (`position: fixed` relative to the viewport per the UA stylesheet), the result surface is anchored using `getBoundingClientRect()` on the host and repositioned:
- once, right before `showPopover()`
- on `window resize`
- on `scroll` of any ancestor scroll container (captured via a capturing `window` listener, since scroll events don't bubble but do reach capturing listeners)

Listeners are cleaned up on close and on `disconnectedCallback`.

## Compatibility / fallback

Support is feature-detected once per module load (`typeof HTMLElement.prototype.showPopover === 'function'`). If unsupported, `topLayer` is a no-op and the element transparently falls back to the original absolutely-positioned behavior - no errors, no visual regression.

Popover API support: Chrome/Edge 114+, Firefox 125+, Safari 17+ ([caniuse](https://caniuse.com/mdn-api_htmlelement_showpopover)). No IE/legacy Edge support - not a concern for evergreen Fusion browser targets, but noting it for the record.

Shadow DOM note: the popover element lives inside the component's shadow root. Top-layer promotion is a rendering/paint effect only - it does not move the element in the DOM, so composed event retargeting (used by the existing outside-click handler) is unaffected.

## Default behavior

Unchanged for existing consumers - `topLayer` defaults to `false`, preserving the current absolutely-positioned, shadow-DOM-relative result list.

## Public API surface (for the fusion-react-components follow-up)

- Package: `@equinor/fusion-wc-searchable-dropdown`
- New public property: `topLayer: boolean` (default `false`), reflected attribute `top-layer`
- Changeset: **minor** version bump
- Exposed on `SearchableDropdownElement` and `SearchableDropdownProps`

## Testing / docs

- New Storybook story `TopLayer` (`storybook/stories/input/searchable-dropdown.stories.ts`) nests the dropdown inside a box with its own stacking context (`transform: translateZ(0)`) plus an overlapping `z-index: 999` overlay, to visually demonstrate the result list escaping it only when `topLayer` is enabled.
- TSDoc updated on the `topLayer` property and regenerated into `custom-elements.json` (verified via `pnpm typedoc`).
- README updated with a "Rendering the result list above arbitrary stacking contexts" usage section.
- Changeset added (`@equinor/fusion-wc-searchable-dropdown`: minor).

## Verification performed

- `pnpm --filter=@equinor/fusion-wc-searchable-dropdown build` (tsc -b + custom-elements manifest generation) - passes
- `pnpm exec biome check` on changed files - passes, no fixes needed
- `pnpm exec tsc -b storybook` - the new/changed story files typecheck cleanly (remaining errors in the storybook project are pre-existing, from other packages not built in this pass)

Refs equinor/fusion-core-tasks#1428

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>