### PR TITLE
Fix layout page scroll containment

### DIFF
--- a/.changeset/layout-page-scroll-containment.md
+++ b/.changeset/layout-page-scroll-containment.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-wc-layout": patch
+"@equinor/fusion-wc-page": patch
+---
+
+Fix height containment so layout and page content fill available space while overflowing page content scrolls inside the main region.

--- a/packages/layout/src/element.css.ts
+++ b/packages/layout/src/element.css.ts
@@ -1,22 +1,48 @@
 import { css, type CSSResult } from 'lit';
 
 export const layoutStyle: CSSResult = css`
+  :host {
+    display: block;
+    height: calc(100vh - var(--header-height, 48px));
+  }
+
   .layout {
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr;
+    grid-template-rows: minmax(0, 1fr);
     height: 100%;
+    max-height: 100vh;
+    min-height: 0;
+    overflow: hidden;
   }
   
   .layout.with-sidebar {
     grid-template-columns: min-content 1fr;
   }
 
+  .content,
+  .sidebar {
+    height: 100%;
+    min-height: 0;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  slot[name="content"],
+  slot[name="sidebar"] {
+    display: block;
+    height: 100%;
+    min-height: 0;
+  }
+
   slot[name="content"]::slotted(*) {
     height: 100%;
+    min-height: 0;
   }
 
   slot[name="sidebar"]::slotted(*) {
     height: 100%;
+    min-height: 0;
   }
 `;
+ 

--- a/packages/layout/src/element.css.ts
+++ b/packages/layout/src/element.css.ts
@@ -45,4 +45,3 @@ export const layoutStyle: CSSResult = css`
     min-height: 0;
   }
 `;
- 

--- a/packages/page/src/components/page/element.css.ts
+++ b/packages/page/src/components/page/element.css.ts
@@ -1,15 +1,23 @@
 import { css, type CSSResult } from 'lit';
 
 export const pageStyle: CSSResult = css`
+  :host {
+    display: block;
+    height: 100%;
+    min-height: 0;
+  }
+
   .page {
     display: grid;
     grid-template-areas: 
       'header'
       'main'
       'footer';
-    grid-template-rows: auto 1fr auto;
+    grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-columns: 1fr;
     height: 100%;
+    min-height: 0;
+    overflow: hidden;
   }
 
   slot[name="header"] {
@@ -18,6 +26,7 @@ export const pageStyle: CSSResult = css`
 
   main {
     grid-area: main;
+    min-height: 0;
     overflow: hidden;
     overflow-y: auto;
   }


### PR DESCRIPTION
## Summary
- Constrain `fwc-layout` and `fwc-page` height chains so slotted content can fill available vertical space.
- Keep overflow contained in the page main region between header and footer.
- Add a dynamic viewport max-height fallback for auto-height layout wrappers.

## Validation
- `pnpm --filter '@equinor/fusion-wc-layout' build`
- `pnpm --filter '@equinor/fusion-wc-page' --filter '@equinor/fusion-wc-layout' build`
- `pnpm exec biome check packages/page/src/components/page/element.css.ts packages/layout/src/element.css.ts`