### PR TITLE
fix: rename app layout and page tags

### DIFF
--- a/.changeset/clever-tags-reflect.md
+++ b/.changeset/clever-tags-reflect.md
@@ -1,0 +1,6 @@
+---
+"@equinor/fusion-wc-layout": minor
+"@equinor/fusion-wc-page": minor
+---
+
+Rename the layout and page custom element tags to `fwc-app-layout` and `fwc-app-page`.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-`fwc-layout` is a structural web component for composing application content into a full-height layout with an optional sidebar.
+`fwc-app-layout` is a structural web component for composing application content into a full-height layout with an optional sidebar.
 
 Use it when an application view needs a stable outer layout where primary content can fill the available space, with sidebar content added only when the view needs secondary navigation, filters, or supporting context.
 
@@ -23,11 +23,11 @@ import '@equinor/fusion-wc-layout';
 ## Usage
 
 ```html
-<fwc-layout>
+<fwc-app-layout>
   <section slot="content">
     Main content
   </section>
-</fwc-layout>
+</fwc-app-layout>
 ```
 
 ## Properties
@@ -48,18 +48,18 @@ import '@equinor/fusion-wc-layout';
 ### Content Only
 
 ```html
-<fwc-layout>
+<fwc-app-layout>
   <section slot="content">
     <h1>Project overview</h1>
     <p>Use the content slot for the main view.</p>
   </section>
-</fwc-layout>
+</fwc-app-layout>
 ```
 
 ### With Sidebar
 
 ```html
-<fwc-layout sidebar>
+<fwc-app-layout sidebar>
   <nav slot="sidebar" style="width: 240px;">
     <a href="/projects">Projects</a>
     <a href="/tasks">Tasks</a>
@@ -69,21 +69,21 @@ import '@equinor/fusion-wc-layout';
     <h1>Active projects</h1>
     <p>The content area fills the remaining horizontal space.</p>
   </section>
-</fwc-layout>
+</fwc-app-layout>
 ```
 
-### With `fwc-page`
+### With `fwc-app-page`
 
 ```html
-<fwc-layout sidebar>
+<fwc-app-layout sidebar>
   <nav slot="sidebar">Sidebar content</nav>
 
-  <fwc-page slot="content">
+  <fwc-app-page slot="content">
     <div slot="header">Header content</div>
     <div slot="main">Main content</div>
     <div slot="footer">Footer content</div>
-  </fwc-page>
-</fwc-layout>
+  </fwc-app-page>
+</fwc-app-layout>
 ```
 
 ### React
@@ -92,10 +92,10 @@ import '@equinor/fusion-wc-layout';
 import '@equinor/fusion-wc-layout';
 
 export const ProjectLayout = () => (
-  <fwc-layout sidebar>
+  <fwc-app-layout sidebar>
     <nav slot="sidebar">Sidebar content</nav>
     <section slot="content">Main content</section>
-  </fwc-layout>
+  </fwc-app-layout>
 );
 ```
 

--- a/packages/layout/src/element.ts
+++ b/packages/layout/src/element.ts
@@ -12,7 +12,7 @@ import { layoutStyle } from './element.css';
  * @slot sidebar - Optional secondary content.
  * @slot content - Primary application content.
  *
- * @tag fwc-layout
+ * @tag fwc-app-layout
  */
 export class LayoutElement extends LitElement implements LayoutElementProps {
   static styles = layoutStyle;

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -5,10 +5,10 @@ import type { LayoutElementProps } from './types';
 export * from './element';
 export * from './types';
 
-export const tag = 'fwc-layout';
+export const tag = 'fwc-app-layout';
 
 /**
- * Entry point for the fwc-layout component.
+ * Entry point for the fwc-app-layout component.
  * Registers the custom element and provides framework typings so it can be
  * used in HTML, TypeScript, and React JSX.
  */

--- a/packages/page/README.md
+++ b/packages/page/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-`fwc-page` is a structural web component for composing application pages with a predictable header, main content, and footer layout.
+`fwc-app-page` is a structural web component for composing application pages with a predictable header, main content, and footer layout.
 
 Use it when a page needs a stable full-height layout where the main content can scroll independently while the header and footer remain in their dedicated regions. The component owns the page grid so consumers only need to provide content for the named slots.
 
@@ -23,7 +23,7 @@ import '@equinor/fusion-wc-page';
 ## Usage
 
 ```html
-<fwc-page>
+<fwc-app-page>
 	<header slot="header">
 		<h1>Project overview</h1>
 	</header>
@@ -35,7 +35,7 @@ import '@equinor/fusion-wc-page';
 	<footer slot="footer">
 		<span>Last updated today</span>
 	</footer>
-</fwc-page>
+</fwc-app-page>
 ```
 
 ## Slots
@@ -51,7 +51,7 @@ import '@equinor/fusion-wc-page';
 ### Page With Actions
 
 ```html
-<fwc-page>
+<fwc-app-page>
 	<div slot="header" style="display: flex; align-items: center; justify-content: space-between; padding: 1rem;">
 		<h1>Portfolio</h1>
 		<button type="button">Create</button>
@@ -65,21 +65,21 @@ import '@equinor/fusion-wc-page';
 	<div slot="footer" style="padding: 1rem;">
 		Showing 24 projects
 	</div>
-</fwc-page>
+</fwc-app-page>
 ```
 
-### With `fwc-layout`
+### With `fwc-app-layout`
 
 ```html
-<fwc-layout sidebar>
+<fwc-app-layout sidebar>
 	<nav slot="sidebar">Sidebar content</nav>
 
-	<fwc-page slot="content">
+	<fwc-app-page slot="content">
 		<div slot="header">Header content</div>
 		<div slot="main">Main content</div>
 		<div slot="footer">Footer content</div>
-	</fwc-page>
-</fwc-layout>
+	</fwc-app-page>
+</fwc-app-layout>
 ```
 
 ### React
@@ -88,11 +88,11 @@ import '@equinor/fusion-wc-page';
 import '@equinor/fusion-wc-page';
 
 export const ProjectPage = () => (
-	<fwc-page>
+	<fwc-app-page>
 		<div slot="header">Project details</div>
 		<div slot="main">Main content</div>
 		<div slot="footer">Status content</div>
-	</fwc-page>
+	</fwc-app-page>
 );
 ```
 

--- a/packages/page/src/components/page/element.ts
+++ b/packages/page/src/components/page/element.ts
@@ -9,7 +9,7 @@ import { pageStyle } from './element.css';
  * @slot main - Primary page content.
  * @slot footer - Optional page footer content.
  *
- * @tag fwc-page
+ * @tag fwc-app-page
  */
 export class PageElement extends LitElement {
   static styles = pageStyle;

--- a/packages/page/src/components/page/index.ts
+++ b/packages/page/src/components/page/index.ts
@@ -3,10 +3,10 @@ import { PageElement } from './element';
 
 export * from './element';
 
-export const tag = 'fwc-page';
+export const tag = 'fwc-app-page';
 
 /**
- * Entry point for the fwc-page component.
+ * Entry point for the fwc-app-page component.
  * Registers the custom element and provides framework typings.
  */
 @fusionElement(tag)

--- a/storybook/stories/data-display/layout.stories.ts
+++ b/storybook/stories/data-display/layout.stories.ts
@@ -16,21 +16,21 @@ setCustomElementsManifest(cem);
 type Story = StoryObj<LayoutElementProps>;
 
 const meta: Meta<typeof cem> = {
-  component: 'fwc-layout',
+  component: 'fwc-app-layout',
 };
 
 const render = (props: LayoutElementProps) => html`
   <div style="height: 650px">
-    <fwc-layout ?sidebar="${ifDefined(props.sidebar)}">
+    <fwc-app-layout ?sidebar="${ifDefined(props.sidebar)}">
       <div slot="sidebar" style="width: 240px;"><p style="padding: 1em">Sidebar content</p></div>
       <div slot="content">
-        <fwc-page>
+        <fwc-app-page>
           <p slot="main" style="padding: 1em">Main content</p>
           <p slot="header" style="padding: 1em">Header content</p>
           <p slot="footer" style="padding: 1em">Footer content</p>
-        </fwc-page>
+        </fwc-app-page>
       </div>
-    </fwc-layout>
+    </fwc-app-layout>
   </div>
 `;
 


### PR DESCRIPTION
## Summary

- Rename the layout custom element tag to `fwc-app-layout`.
- Rename the page custom element tag to `fwc-app-page`.
- Update README examples, Storybook usage, source JSDoc tags, and add a changeset for both packages.

## Testing

- `pnpm --filter='@equinor/fusion-wc-layout' --filter='@equinor/fusion-wc-page' build`
- `pnpm changeset status`
- `pnpm biome check .changeset/clever-tags-reflect.md packages/layout/README.md packages/layout/src/element.ts packages/layout/src/index.ts packages/page/README.md packages/page/src/components/page/element.ts packages/page/src/components/page/index.ts storybook/stories/data-display/layout.stories.ts`
